### PR TITLE
Mocha test failed fix

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -104,7 +104,8 @@ module.exports = function (grunt) {
             dist: {
                 options: {
                     base: '<%%= config.dist %>',
-                    livereload: false
+                    livereload: false,
+                    port: 9001
                 }
             }
         },

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -141,10 +141,8 @@ module.exports = function (grunt) {
         // Mocha testing framework configuration options
         mocha: {
             all: {
-                options: {
-                    run: true,
-                    urls: ['http://<%%= connect.options.hostname %>:<%%= connect.test.options.port %>/index.html']
-                }
+                run: true,
+                urls: ['http://<%%= connect.options.hostname %>:<%%= connect.test.options.port %>/index.html']
             }
         },
 


### PR DESCRIPTION
PhantomJS timed out, possibly due to a missing Mocha run() call. Use --force to continue.
